### PR TITLE
exposed doxygen options EXCLUDE_PATTERNS and FILE_PATTERNS to the ins…

### DIFF
--- a/dub/Inspector.lua
+++ b/dub/Inspector.lua
@@ -12,7 +12,7 @@ local lib     = lub.class 'dub.Inspector'
 local private = {}
 
 
--- Create a new inspector by providing sources to scan. All upercase fields in 
+-- Create a new inspector by providing sources to scan. All upercase fields in
 -- `opts` correspond to options used by Doxygen. The `opts` table can
 -- contain the following keys (keys in parenthesis are optional):
 --
@@ -74,6 +74,44 @@ function private:parse(opts)
   end
   assert(opts and opts.INPUT, "Missing 'INPUT' field")
 
+  if not opts.FILE_PATTERNS then
+    opts.FILE_PATTERNS = [[
+      *.c \
+      *.cc \
+      *.cxx \
+      *.cpp \
+      *.c++ \
+      *.d \
+      *.java \
+      *.ii \
+      *.ixx \
+      *.ipp \
+      *.i++ \
+      *.inl \
+      *.h \
+      *.H \
+      *.hh \
+      *.hxx \
+      *.hpp \
+      *.h++ \
+      *.idl \
+      *.odl \
+      *.cs \
+      *.php \
+      *.php3 \
+      *.inc \
+      *.m \
+      *.mm \
+      *.dox \
+      *.py \
+      *.f90 \
+      *.f \
+      *.for \
+      *.vhd \
+      *.vhdl
+    ]]
+  end
+
   if opts.html then
     opts.GENERATE_HTML = 'YES'
     opts.keep_xml = true
@@ -105,6 +143,14 @@ function private:parse(opts)
     local doxytemplate = lub.Template {path = lub.path('|assets/Doxyfile')}
     if type(opts.INPUT) == 'table' then
       opts.INPUT = lub.join(opts.INPUT, ' ')
+    end
+    if not opts.EXCLUDE_PATTERNS then
+      opts.EXCLUDE_PATTERNS = ''
+    elseif type(opts.EXCLUDE_PATTERNS) == 'table' then
+      opts.EXCLUDE_PATTERNS = lub.join(opts.EXCLUDE_PATTERNS, ' ')
+    end
+    if type(opts.FILE_PATTERNS) == 'table' then
+      opts.FILE_PATTERNS = lub.join(opts.FILE_PATTERNS, ' ')
     end
     if type(opts.PREDEFINED) == 'table' then
       opts.PREDEFINED = lub.join(opts.PREDEFINED, ' \\\n                         ')

--- a/dub/MemoryStorage.lua
+++ b/dub/MemoryStorage.lua
@@ -8,7 +8,7 @@
 local lub     = require 'lub'
 local dub     = require 'dub'
 local xml     = require 'xml'
-local pairs, ipairs, format,        gsub,        match,        insert  = 
+local pairs, ipairs, format,        gsub,        match,        insert  =
       pairs, ipairs, string.format, string.gsub, string.match, table.insert
 local lib     = lub.class 'dub.MemoryStorage'
 local private = {}
@@ -50,8 +50,10 @@ function lib:parse(xml_dir, not_lazy, ignore_list)
   local xml_headers = self.xml_headers
   local dir = lub.Dir(xml_dir)
   -- Parse header (.h) content first
-  for file in dir:glob('_8h.xml') do
-    insert(xml_headers, {path = file, dir = xml_dir})
+  for _, ext in ipairs({'h', 'H', 'hh', 'hxx', 'hpp', 'h++'}) do
+    for file in dir:glob('_8' .. ext .. '.xml') do
+      insert(xml_headers, {path = file, dir = xml_dir})
+    end
   end
   -- Parse namespace content
   for file in dir:glob('namespace.*.xml') do
@@ -227,7 +229,7 @@ function lib:constants(parent)
           end
         end
       end
-    end                                   
+    end
   end)
   return function()
     local ok, name, scope = coroutine.resume(co)
@@ -413,7 +415,7 @@ end
 function private:parseHeaders(name)
   local cache = self.cache
   if self.parsed_headers then
-    return cache[name] 
+    return cache[name]
   end
   local elem
   -- Look in all unparsed headers
@@ -430,7 +432,7 @@ end
 
 local parser = xml.Parser(xml.Parser.TrimWhitespace)
 
---- Parse a header definition and return element 
+--- Parse a header definition and return element
 -- identified by 'name' if found. 'self' can be the db or a dub.Class.
 function parse:header(header, not_lazy)
   header.parsed = true
@@ -587,7 +589,7 @@ end
 
 function parse:sectiondef(elem, header)
   local kind = elem.kind
-  if kind == 'public-func' or 
+  if kind == 'public-func' or
      -- methods
      kind == 'enum' or
      -- global enum
@@ -714,7 +716,7 @@ end
 function parse:typedef(elem, header)
   local typ = {
     type        = 'dub.Typedef',
-    parent      = self, 
+    parent      = self,
     db          = self.db or self,
     name        = find(elem, 'name')[1],
     ctype       = parse.type(elem),
@@ -732,7 +734,7 @@ function parse:typedef(elem, header)
   end
   return typ
 end
-    
+
 parse['function'] = function(self, elem, header)
   local name = find(elem, 'name')[1]
   if self.is_class then
@@ -1020,7 +1022,7 @@ function lib.makeSpecialMethods(class, custom_bindings)
   else
     custom_bindings = {}
   end
-    
+
   if private.needsCast(class.db, class) then
     private.makeCast(class)
   end
@@ -1088,13 +1090,13 @@ function private:makeAttrArrayMethods(attr)
         name     = 'i',
         position = 1,
         ctype    = lib.makeType('size_t'),
-      }, 
+      },
       {
         type     = 'dub.Param',
         name     = 'v',
         position = 2,
         ctype    = attr.ctype,
-      }, 
+      },
     },
     return_value  = nil,
     definition    = 'Write ' .. name,
@@ -1244,7 +1246,7 @@ function parse.opt(elem)
 end
 
 -- function lib:find(scope, name)
---   return self:findByFullname(name) or 
+--   return self:findByFullname(name) or
 --   self:findByFullname(elem.parent:fullname() .. '::' .. name)
 -- end
 

--- a/dub/assets/Doxyfile
+++ b/dub/assets/Doxyfile
@@ -1,9 +1,9 @@
 # Doxyfile 1.7.5.1
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "Dub Bindings"
-PROJECT_NUMBER         = 
-PROJECT_BRIEF          = 
-PROJECT_LOGO           = 
+PROJECT_NUMBER         =
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = "{{doc_dir}}"
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English
@@ -23,8 +23,8 @@ ABBREVIATE_BRIEF       = "The $name class" \
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = YES
-STRIP_FROM_PATH        = 
-STRIP_FROM_INC_PATH    = 
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
 QT_AUTOBRIEF           = NO
@@ -37,7 +37,7 @@ OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
 OPTIMIZE_OUTPUT_VHDL   = NO
-EXTENSION_MAPPING      = 
+EXTENSION_MAPPING      =
 BUILTIN_STL_SUPPORT    = NO
 CPP_CLI_SUPPORT        = NO
 SIP_SUPPORT            = NO
@@ -72,68 +72,36 @@ GENERATE_TODOLIST      = YES
 GENERATE_TESTLIST      = YES
 GENERATE_BUGLIST       = YES
 GENERATE_DEPRECATEDLIST= YES
-ENABLED_SECTIONS       = 
+ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = YES
 SHOW_FILES             = YES
 SHOW_NAMESPACES        = YES
-FILE_VERSION_FILTER    = 
-LAYOUT_FILE            = 
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
 QUIET                  = YES
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = NO
 WARN_IF_DOC_ERROR      = NO
 WARN_NO_PARAMDOC       = NO
 WARN_FORMAT            = "$file:$line: $text"
-WARN_LOGFILE           = 
+WARN_LOGFILE           =
 INPUT                  = {{opts.INPUT}}
 INPUT_ENCODING         = UTF-8
-FILE_PATTERNS          = *.c \
-                         *.cc \
-                         *.cxx \
-                         *.cpp \
-                         *.c++ \
-                         *.d \
-                         *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.h \
-                         *.H \
-                         *.hh \
-                         *.hxx \
-                         *.hpp \
-                         *.h++ \
-                         *.idl \
-                         *.odl \
-                         *.cs \
-                         *.php \
-                         *.php3 \
-                         *.inc \
-                         *.m \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.f90 \
-                         *.f \
-                         *.for \
-                         *.vhd \
-                         *.vhdl
+FILE_PATTERNS          = {{opts.FILE_PATTERNS}}
 RECURSIVE              = {{opts.RECURSIVE or 'NO'}}
-EXCLUDE                = 
+EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = 
-EXCLUDE_SYMBOLS        = 
-EXAMPLE_PATH           = 
+EXCLUDE_PATTERNS       = {{opts.EXCLUDE_PATTERNS}}
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
-IMAGE_PATH             = 
-INPUT_FILTER           = 
-FILTER_PATTERNS        = 
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
-FILTER_SOURCE_PATTERNS = 
+FILTER_SOURCE_PATTERNS =
 SOURCE_BROWSER         = NO
 INLINE_SOURCES         = NO
 STRIP_CODE_COMMENTS    = YES
@@ -144,14 +112,14 @@ USE_HTAGS              = NO
 VERBATIM_HEADERS       = YES
 ALPHABETICAL_INDEX     = YES
 COLS_IN_ALPHA_INDEX    = 5
-IGNORE_PREFIX          = 
+IGNORE_PREFIX          =
 GENERATE_HTML          = {{opts.GENERATE_HTML or 'NO'}}
 HTML_OUTPUT            = html
 HTML_FILE_EXTENSION    = .html
-HTML_HEADER            = 
-HTML_FOOTER            = 
-HTML_STYLESHEET        = 
-HTML_EXTRA_FILES       = 
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_FILES       =
 HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 100
 HTML_COLORSTYLE_GAMMA  = 80
@@ -163,20 +131,20 @@ DOCSET_BUNDLE_ID       = org.doxygen.Project
 DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
 DOCSET_PUBLISHER_NAME  = Publisher
 GENERATE_HTMLHELP      = NO
-CHM_FILE               = 
-HHC_LOCATION           = 
+CHM_FILE               =
+HHC_LOCATION           =
 GENERATE_CHI           = NO
-CHM_INDEX_ENCODING     = 
+CHM_INDEX_ENCODING     =
 BINARY_TOC             = NO
 TOC_EXPAND             = NO
 GENERATE_QHP           = NO
-QCH_FILE               = 
+QCH_FILE               =
 QHP_NAMESPACE          = org.doxygen.Project
 QHP_VIRTUAL_FOLDER     = doc
-QHP_CUST_FILTER_NAME   = 
-QHP_CUST_FILTER_ATTRS  = 
-QHP_SECT_FILTER_ATTRS  = 
-QHG_LOCATION           = 
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
 GENERATE_ECLIPSEHELP   = NO
 ECLIPSE_DOC_ID         = org.doxygen.Project
 DISABLE_INDEX          = NO
@@ -195,9 +163,9 @@ LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
-EXTRA_PACKAGES         = 
-LATEX_HEADER           = 
-LATEX_FOOTER           = 
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
 PDF_HYPERLINKS         = YES
 USE_PDFLATEX           = YES
 LATEX_BATCHMODE        = NO
@@ -207,8 +175,8 @@ GENERATE_RTF           = NO
 RTF_OUTPUT             = rtf
 COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
-RTF_STYLESHEET_FILE    = 
-RTF_EXTENSIONS_FILE    = 
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
 GENERATE_MAN           = NO
 MAN_OUTPUT             = man
 MAN_EXTENSION          = .3
@@ -220,29 +188,29 @@ GENERATE_AUTOGEN_DEF   = NO
 GENERATE_PERLMOD       = NO
 PERLMOD_LATEX          = NO
 PERLMOD_PRETTY         = YES
-PERLMOD_MAKEVAR_PREFIX = 
+PERLMOD_MAKEVAR_PREFIX =
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
-INCLUDE_PATH           = 
-INCLUDE_FILE_PATTERNS  = 
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = {{opts.PREDEFINED}}
-EXPAND_AS_DEFINED      = 
+EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
-TAGFILES               = 
-GENERATE_TAGFILE       = 
+TAGFILES               =
+GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 PERL_PATH              = /usr/bin/perl
 CLASS_DIAGRAMS         = NO
-MSCGEN_PATH            = 
+MSCGEN_PATH            =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO
 DOT_NUM_THREADS        = 0
 DOT_FONTNAME           = Helvetica
 DOT_FONTSIZE           = 10
-DOT_FONTPATH           = 
+DOT_FONTPATH           =
 CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
@@ -255,9 +223,9 @@ CALLER_GRAPH           = NO
 GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
 DOT_IMAGE_FORMAT       = png
-DOT_PATH               = 
-DOTFILE_DIRS           = 
-MSCFILE_DIRS           = 
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
 DOT_GRAPH_MAX_NODES    = 50
 MAX_DOT_GRAPH_DEPTH    = 0
 DOT_TRANSPARENT        = NO


### PR DESCRIPTION
…pector

My project has a large number of Objective-C headers with the `.h` extension, but I only need to bind things in `.hpp` headers which have C++ code, so I've exposed the `FILE_PATTERNS` option.

Moreover, I use boost and I needed to exclude its headers from the bindings, so I've also exposed the `EXCLUDE_PATTERNS` option.

My editor is configured to remove white space at the end of lines, so I'm sorry for the `Doxyfile` diff. Let me know if it's a problem for you.
